### PR TITLE
fix order of arguments for enrichment_analysis in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A standard call to this library would be as follows:
 
 `tissue_df= tea.fetch_dictionary()`
 
-`df_results= tea.enrichment_analysis(tissue_df, gene_list, aname= 'FileName')`
+`df_results= tea.enrichment_analysis(gene_list, tissue_df, aname= 'FileName')`
 
 `tea.plot_enrichment_results(df_results, title= 'FileName')`
 


### PR DESCRIPTION
The argument positions of `gene_list` and `tissue_df` for the `enrichment_analysis` function are swapped in the Within a Python Script section of the [README.md](https://github.com/dangeles/TissueEnrichmentAnalysis/blob/7b64f8f58cb4aef7d64f239960d9038a8728d0ed/README.md). The function definition in [hypergeometricTests.py](https://github.com/dangeles/TissueEnrichmentAnalysis/blob/7b64f8f58cb4aef7d64f239960d9038a8728d0ed/tissue_enrichment_analysis/hypergeometricTests.py) has `gene_list` before `tissue_df`. This commit fixes the README to be consistent with this function definition.